### PR TITLE
new: optional work session reminder, restricted to super-admin

### DIFF
--- a/app/Domain/WorkSessions/Actions/StartWorkSessionAction.php
+++ b/app/Domain/WorkSessions/Actions/StartWorkSessionAction.php
@@ -24,13 +24,14 @@ final class StartWorkSessionAction
         }
 
         $startedAt = now();
+        $reminderEnabled = (bool) AppSetting::getValue(AppSettingKey::WorkSessionReminderEnabled, true);
         $delayMinutes = (int) AppSetting::getValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
 
         return WorkSession::create([
             'user_id' => $dto->userId,
             'work_date' => $dto->workDate->toDateString(),
             'started_at' => $startedAt,
-            'reminder_due_at' => $startedAt->copy()->addMinutes($delayMinutes),
+            'reminder_due_at' => $reminderEnabled ? $startedAt->copy()->addMinutes($delayMinutes) : null,
         ]);
     }
 }

--- a/app/Enums/AppSettingKey.php
+++ b/app/Enums/AppSettingKey.php
@@ -8,4 +8,5 @@ enum AppSettingKey: string
 {
     case OfficialSignerUserId = 'official_signer_user_id';
     case WorkSessionReminderDelayMinutes = 'work_session_reminder_delay_minutes';
+    case WorkSessionReminderEnabled = 'work_session_reminder_enabled';
 }

--- a/app/Livewire/Settings/WorkSessionSettings.php
+++ b/app/Livewire/Settings/WorkSessionSettings.php
@@ -5,17 +5,27 @@ declare(strict_types=1);
 namespace App\Livewire\Settings;
 
 use App\Enums\AppSettingKey;
-use App\Enums\PermissionKey;
+use App\Enums\RoleKey;
 use App\Models\AppSetting;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 
 class WorkSessionSettings extends Component
 {
+    public bool $reminderEnabled = true;
+
     public int $reminderDelayMinutes = 120;
 
     public function mount(): void
     {
+        abort_unless(Auth::user()?->hasRole(RoleKey::SuperAdmin->value), 403);
+
+        $this->reminderEnabled = (bool) AppSetting::getValue(
+            AppSettingKey::WorkSessionReminderEnabled,
+            true
+        );
+
         $this->reminderDelayMinutes = (int) AppSetting::getValue(
             AppSettingKey::WorkSessionReminderDelayMinutes,
             120
@@ -24,16 +34,21 @@ class WorkSessionSettings extends Component
 
     public function save(): void
     {
-        $this->authorize(PermissionKey::ManageSettings->value);
+        abort_unless(Auth::user()?->hasRole(RoleKey::SuperAdmin->value), 403);
 
         $this->validate([
-            'reminderDelayMinutes' => ['required', 'integer', 'min:15', 'max:480'],
+            'reminderEnabled' => ['required', 'boolean'],
+            'reminderDelayMinutes' => ['exclude_if:reminderEnabled,false', 'required', 'integer', 'min:15', 'max:480'],
         ]);
 
-        AppSetting::setValue(
-            AppSettingKey::WorkSessionReminderDelayMinutes,
-            $this->reminderDelayMinutes
-        );
+        AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, $this->reminderEnabled);
+
+        if ($this->reminderEnabled) {
+            AppSetting::setValue(
+                AppSettingKey::WorkSessionReminderDelayMinutes,
+                $this->reminderDelayMinutes
+            );
+        }
 
         session()->flash('status', 'Podešavanja sačuvana.');
     }

--- a/resources/views/layouts/app/sidebar.blade.php
+++ b/resources/views/layouts/app/sidebar.blade.php
@@ -174,11 +174,11 @@
                         <flux:sidebar.item class="ps-9" icon="tag" :href="route('settings.issue-categories.index')" :current="request()->routeIs('settings.issue-categories.*')" wire:navigate>
                             @lang('messages.menu.catIssues')
                         </flux:sidebar.item>
-                        @can('manage-settings')
+                        @role('super-admin')
                             <flux:sidebar.item class="ps-9" icon="clock" :href="route('settings.work-session')" :current="request()->routeIs('settings.work-session')" wire:navigate>
                                 Radni dan
                             </flux:sidebar.item>
-                        @endcan
+                        @endrole
                     </div>
                 </div>
             </flux:sidebar.nav>

--- a/resources/views/livewire/settings/work-session-settings.blade.php
+++ b/resources/views/livewire/settings/work-session-settings.blade.php
@@ -8,13 +8,21 @@
         <flux:callout variant="success" icon="check-circle">{{ session('status') }}</flux:callout>
     @endif
 
-    <form wire:submit.prevent="save" class="max-w-sm space-y-4">
-        <flux:field>
-            <flux:label>Kašnjenje podsetnika (minuti)</flux:label>
-            <flux:description>Koliko minuta nakon početka radnog dana da se prikaže podsetnik.</flux:description>
-            <flux:input wire:model="reminderDelayMinutes" type="number" min="15" max="480" />
-            <flux:error name="reminderDelayMinutes" />
+    <form wire:submit.prevent="save" class="max-w-sm space-y-4" x-data="{ enabled: @js($reminderEnabled) }">
+        <flux:field variant="inline">
+            <flux:switch wire:model="reminderEnabled" x-model="enabled" />
+            <flux:label>Podsetnik uključen</flux:label>
+            <flux:error name="reminderEnabled" />
         </flux:field>
+
+        <div x-show="enabled" x-collapse>
+            <flux:field>
+                <flux:label>Kašnjenje podsetnika (minuti)</flux:label>
+                <flux:description>Koliko minuta nakon početka radnog dana da se prikaže podsetnik.</flux:description>
+                <flux:input wire:model="reminderDelayMinutes" type="number" min="15" max="480" />
+                <flux:error name="reminderDelayMinutes" />
+            </flux:field>
+        </div>
 
         <flux:button type="submit" variant="primary">Sačuvaj</flux:button>
     </form>

--- a/tests/Feature/Domain/WorkSessions/WorkSessionActionsTest.php
+++ b/tests/Feature/Domain/WorkSessions/WorkSessionActionsTest.php
@@ -6,6 +6,8 @@ use App\Domain\WorkSessions\DTO\FinishWorkSessionData;
 use App\Domain\WorkSessions\DTO\StartWorkSessionData;
 use App\Domain\WorkSessions\Exceptions\WorkSessionAlreadyStartedException;
 use App\Domain\WorkSessions\Exceptions\WorkSessionNotStartedException;
+use App\Enums\AppSettingKey;
+use App\Models\AppSetting;
 use App\Models\User;
 use App\Models\WorkSession;
 
@@ -20,11 +22,24 @@ test('StartWorkSessionAction creates a work session for today', function () {
         ->and($session->user_id)->toBe($user->id)
         ->and($session->work_date->toDateString())->toBe(today()->toDateString())
         ->and($session->started_at)->not->toBeNull()
-        ->and($session->ended_at)->toBeNull();
+        ->and($session->ended_at)->toBeNull()
+        ->and($session->reminder_due_at)->not->toBeNull();
 
     expect(
         WorkSession::query()->where('user_id', $user->id)->whereDate('work_date', today())->exists()
     )->toBeTrue();
+});
+
+test('StartWorkSessionAction does not set reminder_due_at when reminder is disabled', function () {
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, false);
+
+    $user = User::factory()->create();
+
+    $session = app(StartWorkSessionAction::class)->execute(
+        StartWorkSessionData::fromArray(['user_id' => $user->id])
+    );
+
+    expect($session->reminder_due_at)->toBeNull();
 });
 
 test('StartWorkSessionAction throws WorkSessionAlreadyStartedException if session exists today', function () {

--- a/tests/Feature/Livewire/WorkSessionSettingsTest.php
+++ b/tests/Feature/Livewire/WorkSessionSettingsTest.php
@@ -11,30 +11,33 @@ beforeEach(function () {
     (new \Database\Seeders\RolesAndPermissionsSeeder)->run();
 });
 
-test('settings form loads with default delay when not configured', function () {
-    $user = User::factory()->create();
-    $user->givePermissionTo('manage-settings');
-    $this->actingAs($user);
+test('settings form loads with default values when not configured', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
 
     Livewire::test(WorkSessionSettings::class)
+        ->assertSet('reminderEnabled', true)
         ->assertSet('reminderDelayMinutes', 120);
 });
 
-test('settings form loads configured delay', function () {
+test('settings form loads configured values', function () {
     AppSetting::setValue(AppSettingKey::WorkSessionReminderDelayMinutes, 60);
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, false);
 
-    $user = User::factory()->create();
-    $user->givePermissionTo('manage-settings');
-    $this->actingAs($user);
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
 
     Livewire::test(WorkSessionSettings::class)
+        ->assertSet('reminderEnabled', false)
         ->assertSet('reminderDelayMinutes', 60);
 });
 
 test('save persists reminder delay to app settings', function () {
-    $user = User::factory()->create();
-    $user->givePermissionTo('manage-settings');
-    $this->actingAs($user);
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
 
     Livewire::test(WorkSessionSettings::class)
         ->set('reminderDelayMinutes', 90)
@@ -45,12 +48,35 @@ test('save persists reminder delay to app settings', function () {
 });
 
 test('save validates minimum delay of 15 minutes', function () {
-    $user = User::factory()->create();
-    $user->givePermissionTo('manage-settings');
-    $this->actingAs($user);
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
 
     Livewire::test(WorkSessionSettings::class)
         ->set('reminderDelayMinutes', 5)
         ->call('save')
         ->assertHasErrors(['reminderDelayMinutes']);
+});
+
+test('save can disable reminder without validating delay', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
+
+    Livewire::test(WorkSessionSettings::class)
+        ->set('reminderEnabled', false)
+        ->set('reminderDelayMinutes', 5)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect((bool) AppSetting::getValue(AppSettingKey::WorkSessionReminderEnabled))->toBeFalse();
+});
+
+test('non-super-admin cannot view work session settings', function () {
+    $user = User::factory()->create();
+    $user->givePermissionTo('manage-settings');
+    $this->actingAs($user);
+
+    Livewire::test(WorkSessionSettings::class)
+        ->assertForbidden();
 });


### PR DESCRIPTION
Allows tracking work time without the reminder popup, and restricts the work-session reminder settings to super-admin only.