### PR TITLE
new: per-user work session reminder override

### DIFF
--- a/app/Domain/WorkSessions/Actions/StartWorkSessionAction.php
+++ b/app/Domain/WorkSessions/Actions/StartWorkSessionAction.php
@@ -9,6 +9,7 @@ use App\Domain\WorkSessions\Exceptions\WorkSessionAlreadyStartedException;
 use App\Enums\AppSettingKey;
 use App\Models\AppSetting;
 use App\Models\WorkSession;
+use App\Models\WorkSessionUserSetting;
 
 final class StartWorkSessionAction
 {
@@ -24,8 +25,14 @@ final class StartWorkSessionAction
         }
 
         $startedAt = now();
-        $reminderEnabled = (bool) AppSetting::getValue(AppSettingKey::WorkSessionReminderEnabled, true);
-        $delayMinutes = (int) AppSetting::getValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
+
+        $userSetting = WorkSessionUserSetting::query()->where('user_id', $dto->userId)->first();
+
+        $reminderEnabled = $userSetting?->reminder_enabled
+            ?? (bool) AppSetting::getValue(AppSettingKey::WorkSessionReminderEnabled, true);
+
+        $delayMinutes = $userSetting?->reminder_delay_minutes
+            ?? (int) AppSetting::getValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
 
         return WorkSession::create([
             'user_id' => $dto->userId,

--- a/app/Domain/WorkSessions/Actions/UpsertWorkSessionUserSettingAction.php
+++ b/app/Domain/WorkSessions/Actions/UpsertWorkSessionUserSettingAction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\WorkSessions\Actions;
+
+use App\Domain\WorkSessions\DTO\UpsertWorkSessionUserSettingData;
+use App\Models\WorkSessionUserSetting;
+
+final class UpsertWorkSessionUserSettingAction
+{
+    public function execute(UpsertWorkSessionUserSettingData $dto): WorkSessionUserSetting
+    {
+        return WorkSessionUserSetting::query()->updateOrCreate(
+            ['user_id' => $dto->userId],
+            [
+                'reminder_enabled' => $dto->reminderEnabled,
+                'reminder_delay_minutes' => $dto->reminderEnabled ? $dto->reminderDelayMinutes : null,
+            ],
+        );
+    }
+}

--- a/app/Domain/WorkSessions/DTO/UpsertWorkSessionUserSettingData.php
+++ b/app/Domain/WorkSessions/DTO/UpsertWorkSessionUserSettingData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\WorkSessions\DTO;
+
+final readonly class UpsertWorkSessionUserSettingData
+{
+    public function __construct(
+        public int $userId,
+        public bool $reminderEnabled,
+        public ?int $reminderDelayMinutes,
+    ) {}
+
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            userId: (int) $data['user_id'],
+            reminderEnabled: (bool) $data['reminder_enabled'],
+            reminderDelayMinutes: isset($data['reminder_delay_minutes']) ? (int) $data['reminder_delay_minutes'] : null,
+        );
+    }
+}

--- a/app/Livewire/Admin/WorkSessions/Index.php
+++ b/app/Livewire/Admin/WorkSessions/Index.php
@@ -7,12 +7,17 @@ namespace App\Livewire\Admin\WorkSessions;
 use App\Domain\WorkSessions\Actions\ForceDeleteWorkSessionAction;
 use App\Domain\WorkSessions\Actions\ForceFinishWorkSessionAction;
 use App\Domain\WorkSessions\Actions\GenerateWorkSessionReportPdfAction;
+use App\Domain\WorkSessions\Actions\UpsertWorkSessionUserSettingAction;
 use App\Domain\WorkSessions\DTO\ForceDeleteWorkSessionData;
 use App\Domain\WorkSessions\DTO\ForceFinishWorkSessionData;
 use App\Domain\WorkSessions\DTO\GenerateWorkSessionReportData;
+use App\Domain\WorkSessions\DTO\UpsertWorkSessionUserSettingData;
+use App\Enums\AppSettingKey;
 use App\Enums\RoleKey;
+use App\Models\AppSetting;
 use App\Models\User;
 use App\Models\WorkSession;
+use App\Models\WorkSessionUserSetting;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
@@ -40,6 +45,16 @@ class Index extends Component
     public string $reportDateFrom = '';
 
     public string $reportDateTo = '';
+
+    public bool $showUserSettingsModal = false;
+
+    public ?int $userSettingsUserId = null;
+
+    public string $userSettingsUserName = '';
+
+    public bool $userSettingsReminderEnabled = true;
+
+    public int $userSettingsReminderDelayMinutes = 120;
 
     public function updatedSelectedUserId(): void
     {
@@ -93,6 +108,43 @@ class Index extends Component
 
         $this->pendingDeleteId = null;
         $this->showDeleteConfirm = false;
+    }
+
+    public function openUserSettings(int $userId): void
+    {
+        abort_unless(Auth::user()?->hasRole(RoleKey::SuperAdmin->value), 403);
+
+        $user = User::query()->findOrFail($userId);
+        $userSetting = WorkSessionUserSetting::query()->where('user_id', $userId)->first();
+
+        $this->userSettingsUserId = $userId;
+        $this->userSettingsUserName = $user->name;
+        $this->userSettingsReminderEnabled = $userSetting?->reminder_enabled
+            ?? (bool) AppSetting::getValue(AppSettingKey::WorkSessionReminderEnabled, true);
+        $this->userSettingsReminderDelayMinutes = $userSetting?->reminder_delay_minutes
+            ?? (int) AppSetting::getValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
+        $this->showUserSettingsModal = true;
+    }
+
+    public function saveUserSettings(): void
+    {
+        abort_unless(Auth::user()?->hasRole(RoleKey::SuperAdmin->value), 403);
+
+        $this->validate([
+            'userSettingsReminderEnabled' => ['required', 'boolean'],
+            'userSettingsReminderDelayMinutes' => ['exclude_if:userSettingsReminderEnabled,false', 'required', 'integer', 'min:15', 'max:480'],
+        ]);
+
+        app(UpsertWorkSessionUserSettingAction::class)->execute(
+            UpsertWorkSessionUserSettingData::fromArray([
+                'user_id' => $this->userSettingsUserId,
+                'reminder_enabled' => $this->userSettingsReminderEnabled,
+                'reminder_delay_minutes' => $this->userSettingsReminderDelayMinutes,
+            ])
+        );
+
+        $this->userSettingsUserId = null;
+        $this->showUserSettingsModal = false;
     }
 
     public function downloadReport(): BinaryFileResponse

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -109,4 +109,9 @@ class User extends Authenticatable
     {
         return $this->hasMany(WorkSession::class);
     }
+
+    public function workSessionUserSetting(): HasOne
+    {
+        return $this->hasOne(WorkSessionUserSetting::class);
+    }
 }

--- a/app/Models/WorkSessionUserSetting.php
+++ b/app/Models/WorkSessionUserSetting.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WorkSessionUserSetting extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'reminder_enabled',
+        'reminder_delay_minutes',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'reminder_enabled' => 'boolean',
+        ];
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_06_10_093407_create_work_session_user_settings_table.php
+++ b/database/migrations/2026_06_10_093407_create_work_session_user_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('work_session_user_settings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->boolean('reminder_enabled')->nullable();
+            $table->unsignedInteger('reminder_delay_minutes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('work_session_user_settings');
+    }
+};

--- a/resources/views/livewire/admin/work-sessions/index.blade.php
+++ b/resources/views/livewire/admin/work-sessions/index.blade.php
@@ -89,7 +89,19 @@
         <x-ui.table.body>
             @forelse ($sessions as $session)
                 <x-ui.table.row>
-                    <x-ui.table.td>{{ $session->user->name }}</x-ui.table.td>
+                    <x-ui.table.td>
+                        @role('super-admin')
+                            <button
+                                type="button"
+                                wire:click="openUserSettings({{ $session->user->id }})"
+                                class="underline decoration-dotted hover:text-zinc-900 dark:hover:text-zinc-100"
+                            >
+                                {{ $session->user->name }}
+                            </button>
+                        @else
+                            {{ $session->user->name }}
+                        @endrole
+                    </x-ui.table.td>
                     <x-ui.table.td>{{ $session->work_date->format('d.m.Y') }}</x-ui.table.td>
                     <x-ui.table.td>{{ $session->started_at->format('H:i') }}</x-ui.table.td>
                     <x-ui.table.td>
@@ -186,5 +198,38 @@
                 </flux:button>
             </div>
         </div>
+    </flux:modal>
+
+    <flux:modal name="work-session-user-settings" wire:model="showUserSettingsModal" class="max-w-md">
+        <form wire:submit.prevent="saveUserSettings" class="space-y-5" x-data="{ enabled: @entangle('userSettingsReminderEnabled') }">
+            <div>
+                <flux:heading size="lg">Podsetnik za korisnika</flux:heading>
+                <flux:subheading>{{ $userSettingsUserName }}</flux:subheading>
+            </div>
+
+            <flux:field variant="inline">
+                <flux:switch x-model="enabled" />
+                <flux:label>Podsetnik uključen</flux:label>
+                <flux:error name="userSettingsReminderEnabled" />
+            </flux:field>
+
+            <div x-show="enabled" x-collapse>
+                <flux:field>
+                    <flux:label>Kašnjenje podsetnika (minuti)</flux:label>
+                    <flux:description>Koliko minuta nakon početka radnog dana da se prikaže podsetnik ovom korisniku.</flux:description>
+                    <flux:input wire:model="userSettingsReminderDelayMinutes" type="number" min="15" max="480" />
+                    <flux:error name="userSettingsReminderDelayMinutes" />
+                </flux:field>
+            </div>
+
+            <div class="flex justify-end gap-2">
+                <flux:modal.close>
+                    <flux:button variant="filled">Otkaži</flux:button>
+                </flux:modal.close>
+                <flux:button type="submit" variant="primary" wire:loading.attr="disabled">
+                    Sačuvaj
+                </flux:button>
+            </div>
+        </form>
     </flux:modal>
 </div>

--- a/tests/Feature/Domain/WorkSessions/WorkSessionActionsTest.php
+++ b/tests/Feature/Domain/WorkSessions/WorkSessionActionsTest.php
@@ -2,14 +2,17 @@
 
 use App\Domain\WorkSessions\Actions\FinishWorkSessionAction;
 use App\Domain\WorkSessions\Actions\StartWorkSessionAction;
+use App\Domain\WorkSessions\Actions\UpsertWorkSessionUserSettingAction;
 use App\Domain\WorkSessions\DTO\FinishWorkSessionData;
 use App\Domain\WorkSessions\DTO\StartWorkSessionData;
+use App\Domain\WorkSessions\DTO\UpsertWorkSessionUserSettingData;
 use App\Domain\WorkSessions\Exceptions\WorkSessionAlreadyStartedException;
 use App\Domain\WorkSessions\Exceptions\WorkSessionNotStartedException;
 use App\Enums\AppSettingKey;
 use App\Models\AppSetting;
 use App\Models\User;
 use App\Models\WorkSession;
+use App\Models\WorkSessionUserSetting;
 
 test('StartWorkSessionAction creates a work session for today', function () {
     $user = User::factory()->create();
@@ -34,6 +37,41 @@ test('StartWorkSessionAction does not set reminder_due_at when reminder is disab
     AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, false);
 
     $user = User::factory()->create();
+
+    $session = app(StartWorkSessionAction::class)->execute(
+        StartWorkSessionData::fromArray(['user_id' => $user->id])
+    );
+
+    expect($session->reminder_due_at)->toBeNull();
+});
+
+test('StartWorkSessionAction uses per-user reminder override when global reminder is enabled', function () {
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, true);
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
+
+    $user = User::factory()->create();
+    WorkSessionUserSetting::create([
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 480,
+    ]);
+
+    $session = app(StartWorkSessionAction::class)->execute(
+        StartWorkSessionData::fromArray(['user_id' => $user->id])
+    );
+
+    expect($session->started_at->diffInMinutes($session->reminder_due_at))->toBe(480.0);
+});
+
+test('StartWorkSessionAction does not set reminder_due_at when per-user override disables it', function () {
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, true);
+
+    $user = User::factory()->create();
+    WorkSessionUserSetting::create([
+        'user_id' => $user->id,
+        'reminder_enabled' => false,
+        'reminder_delay_minutes' => null,
+    ]);
 
     $session = app(StartWorkSessionAction::class)->execute(
         StartWorkSessionData::fromArray(['user_id' => $user->id])
@@ -102,4 +140,64 @@ test('FinishWorkSessionAction is idempotent when session is already finished', f
 
     expect($result->duration_minutes)->toBe(90)
         ->and($result->ended_at->toDateTimeString())->toBe($endedAt->toDateTimeString());
+});
+
+test('UpsertWorkSessionUserSettingAction creates an override for a user', function () {
+    $user = User::factory()->create();
+
+    app(UpsertWorkSessionUserSettingAction::class)->execute(
+        UpsertWorkSessionUserSettingData::fromArray([
+            'user_id' => $user->id,
+            'reminder_enabled' => true,
+            'reminder_delay_minutes' => 30,
+        ])
+    );
+
+    $this->assertDatabaseHas('work_session_user_settings', [
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 30,
+    ]);
+});
+
+test('UpsertWorkSessionUserSettingAction updates an existing override', function () {
+    $user = User::factory()->create();
+    WorkSessionUserSetting::create([
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 30,
+    ]);
+
+    app(UpsertWorkSessionUserSettingAction::class)->execute(
+        UpsertWorkSessionUserSettingData::fromArray([
+            'user_id' => $user->id,
+            'reminder_enabled' => true,
+            'reminder_delay_minutes' => 480,
+        ])
+    );
+
+    $this->assertDatabaseHas('work_session_user_settings', [
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 480,
+    ]);
+    $this->assertDatabaseCount('work_session_user_settings', 1);
+});
+
+test('UpsertWorkSessionUserSettingAction clears delay when reminder is disabled', function () {
+    $user = User::factory()->create();
+
+    app(UpsertWorkSessionUserSettingAction::class)->execute(
+        UpsertWorkSessionUserSettingData::fromArray([
+            'user_id' => $user->id,
+            'reminder_enabled' => false,
+            'reminder_delay_minutes' => 30,
+        ])
+    );
+
+    $this->assertDatabaseHas('work_session_user_settings', [
+        'user_id' => $user->id,
+        'reminder_enabled' => false,
+        'reminder_delay_minutes' => null,
+    ]);
 });

--- a/tests/Feature/Livewire/WorkSessions/AdminWorkSessionsTest.php
+++ b/tests/Feature/Livewire/WorkSessions/AdminWorkSessionsTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use App\Enums\AppSettingKey;
 use App\Livewire\Admin\WorkSessions\Index;
+use App\Models\AppSetting;
 use App\Models\User;
 use App\Models\WorkSession;
+use App\Models\WorkSessionUserSetting;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -265,4 +268,94 @@ test('index filters by date', function () {
     Livewire::test(Index::class)
         ->set('selectedDate', '2026-06-08')
         ->assertSee('Nema pronađenih sesija.');
+});
+
+test('super-admin can open user reminder settings prefilled with global defaults', function () {
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderEnabled, true);
+    AppSetting::setValue(AppSettingKey::WorkSessionReminderDelayMinutes, 120);
+
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+
+    Livewire::test(Index::class)
+        ->call('openUserSettings', $user->id)
+        ->assertSet('showUserSettingsModal', true)
+        ->assertSet('userSettingsUserId', $user->id)
+        ->assertSet('userSettingsReminderEnabled', true)
+        ->assertSet('userSettingsReminderDelayMinutes', 120);
+});
+
+test('super-admin can open user reminder settings prefilled with existing override', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+    WorkSessionUserSetting::create([
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 480,
+    ]);
+
+    Livewire::test(Index::class)
+        ->call('openUserSettings', $user->id)
+        ->assertSet('userSettingsReminderDelayMinutes', 480);
+});
+
+test('super-admin can save a per-user reminder override', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+
+    Livewire::test(Index::class)
+        ->call('openUserSettings', $user->id)
+        ->set('userSettingsReminderEnabled', true)
+        ->set('userSettingsReminderDelayMinutes', 480)
+        ->call('saveUserSettings')
+        ->assertHasNoErrors()
+        ->assertSet('showUserSettingsModal', false);
+
+    $this->assertDatabaseHas('work_session_user_settings', [
+        'user_id' => $user->id,
+        'reminder_enabled' => true,
+        'reminder_delay_minutes' => 480,
+    ]);
+});
+
+test('super-admin can disable reminder for a specific user', function () {
+    $admin = User::factory()->create();
+    $admin->assignRole('super-admin');
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+
+    Livewire::test(Index::class)
+        ->call('openUserSettings', $user->id)
+        ->set('userSettingsReminderEnabled', false)
+        ->set('userSettingsReminderDelayMinutes', 5)
+        ->call('saveUserSettings')
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('work_session_user_settings', [
+        'user_id' => $user->id,
+        'reminder_enabled' => false,
+        'reminder_delay_minutes' => null,
+    ]);
+});
+
+test('non-super-admin cannot open user reminder settings', function () {
+    $admin = User::factory()->create();
+    $admin->givePermissionTo('manage-users');
+    $this->actingAs($admin);
+
+    $user = User::factory()->create();
+
+    Livewire::test(Index::class)
+        ->call('openUserSettings', $user->id)
+        ->assertForbidden();
 });


### PR DESCRIPTION
Lets super-admin override the global reminder enable/delay settings for an individual user from the admin work sessions overview, e.g. a longer delay for users with full-day shifts.